### PR TITLE
 Change engine field to be >=8 instead of ^8

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "license": "MIT",
   "engines": {
-    "node": "^8.0"
+    "node": ">=8.0"
   }
 }


### PR DESCRIPTION
This makes sure it works in packagers that honor the field with node v9 and onwards, for example yarn withouth the --ignore-engines argument.