### PR TITLE
Do not show timer.js and async_hooks.js internals in stack trace

### DIFF
--- a/trace.js
+++ b/trace.js
@@ -18,9 +18,11 @@ const traces = new Map();
 chain.filter.attach(function (error, frames) {
   return frames.filter(function (callSite) {
     const name = callSite && callSite.getFileName();
-    return (!name || name !== 'async_hooks.js');
+    return (!name || !INTERNALS.includes(name))
   });
 });
+
+const INTERNALS = ['async_hooks.js', 'internal/async_hooks.js'];
 
 chain.extend.attach(function (error, frames) {
   const lastTrace = traces.get(asyncHook.executionAsyncId());


### PR DESCRIPTION
```js
require('trace');

Error.stackTraceLimit = 20;

setTimeout(function printStack () {
  console.log((new Error).stack);
}, 0);
```

prints:

```
Error
    at Timeout.printStack [as _onTimeout] (/home/ether/Desktop/test.js:6:16)
    at ontimeout (timers.js:427:11)
    at tryOnTimeout (timers.js:289:5)
    at listOnTimeout (timers.js:252:5)
    at Timer.processTimers (timers.js:212:10)
    at emitInitNative (internal/async_hooks.js:137:43)
    at emitInitScript (internal/async_hooks.js:336:3)
    at initAsyncResource (internal/timers.js:50:5)
    at new Timeout (internal/timers.js:82:3)
    at setTimeout (timers.js:403:19)
    at Object.<anonymous> (/home/ether/Desktop/test.js:5:1)
    at Module._compile (internal/modules/cjs/loader.js:678:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:689:10)
    at Module.load (internal/modules/cjs/loader.js:589:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:528:12)
    at Function.Module._load (internal/modules/cjs/loader.js:520:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:719:10)
    at startup (internal/bootstrap/node.js:228:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:576:3)
```

This is for Node `10.1.0` but the output is similar for Node `8.11.0`.

With the current PR, it would print instead:

```
Error
    at Timeout.printStack [as _onTimeout] (/home/ether/Desktop/test.js:6:16)
    at Object.<anonymous> (/home/ether/Desktop/test.js:5:1)
    at Module._compile (internal/modules/cjs/loader.js:678:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:689:10)
    at Module.load (internal/modules/cjs/loader.js:589:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:528:12)
    at Function.Module._load (internal/modules/cjs/loader.js:520:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:719:10)
    at startup (internal/bootstrap/node.js:228:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:576:3)
```